### PR TITLE
Scheme for Emulators

### DIFF
--- a/PQ9Emulators.py
+++ b/PQ9Emulators.py
@@ -1,0 +1,132 @@
+import queue
+
+class PQ9Emulator:
+    '''
+    Template of emulators. 
+    To use an emulator, try XXXEmulator.processCommand(), which is like PQ9Client.processCommand()
+    '''
+
+    def __init__(self, addr):
+        '''Input: address number (string) of the emulator on PQ9 bus'''
+
+        self.services = {'17':self.PingService, '3':self.HouseKeepingService} #TODO
+        self.addr = addr
+
+    def processCommand(self, cmd):
+        '''
+        Call a service to process the command. 
+        This function will be rewritten in the emulator for OBC.
+
+        Input: 
+            cmd	the dictationary of the command. It has to use 'SendRaw'
+        Output: 
+            state	it can be True/False/'pause'
+            reply	the dictationary of the reply
+        '''
+
+        # Extract information from the command
+        rawMsg, cmdSrc, cmdDest, serviceNum, cmdPayload = self.FrameToData(cmd)
+
+        # Verification
+        assert cmdDest == self.addr, "processCommand(): This command is not for %s, but for %s!" % (self.addr, cmdDest)
+        assert serviceNum in self.services, "processCommand(): I don't have service %s" % serviceNum
+
+        # Process the command
+        state, replyPayload = self.services[serviceNum](cmdPayload)
+
+        # Set the reply
+        reply = self.DataToFrame(self.addr, cmdSrc, replyPayload)
+
+        return state, reply
+
+    def FrameToData(self, cmd):
+        '''
+        Extract information from the command
+
+        Input: 
+            cmd		the dictationary of the command. It has to use 'SendRaw'
+        Output:
+            rawMsg		list of each bit in the raw command
+            payload		list of each bit in the payload of the command
+            src, dest,serviceNum	information in the command
+        '''
+
+        # TODO: fix the server so there are no 2 similar keys
+        if '_raw_' in cmd:
+            rawMsg = cmd['_raw_'].split()
+            src = rawMsg[0]
+            dest = rawMsg[2]
+            serviceNum = rawMsg[3]
+            payload = rawMsg[3:]
+        elif 'data' in cmd:
+            rawMsg = cmd['data'].split()
+            src = cmd['src']
+            dest = cmd['dest']
+            serviceNum = rawMsg[0]
+            payload = rawMsg
+        else:
+            assert False, "FrameToData(): 'SendRaw' rather than %s should be used" % cmd['_send_']
+        return rawMsg, src, dest, serviceNum, payload
+
+    def DataToFrame(self, src, dest, payload):
+        '''
+        Integrate a PQ9Frame according to the information
+
+        Input:
+            payload		list of each bit in the payload of the frame
+            src, dest,serviceNum	information in the frame
+        Output: 
+            reply		the dictationary of the frame. It uses 'SendRaw'
+        '''
+
+        # TODO: fix the server so there are no 2 similar keys
+        reply = {}
+        reply['_send_'] = "SendRaw"
+        reply['dest'] = dest
+        reply['src'] = src
+        reply['data'] = ' '.join(payload)
+        reply['_raw_'] = ' '.join([src, str(len(payload)+3), dest] + payload)
+        return reply
+
+    def PingService(self, cmdPayload):
+        return True, ['17', '2']
+
+    def HouseKeepingService(self, cmdPayload): # TODO
+        return True, ['3', '2', '0']
+
+
+class COMMSEmulator(PQ9Emulator):
+
+    def __init__(self, addr):
+        PQ9Emulator.__init__(self, addr)
+        self.services['20'] = self.RadioService
+        self.RXBuffer = queue.Queue()
+        self.TXBuffer = queue.Queue()
+
+    def RadioService(self, cmdPayload): 
+        '''
+        If master sends a frame to COMMS, this service saves the dictationary of the frame in TXBuffer 
+        and returns 'pause' so the PQ9VirtualBus stops. Then users can check status of COMMS.
+        If master takes a frame frome COMMS, this service takes the dictationary of the frame from RXBuffer.
+        TODO: to be expanded
+
+        Input:
+            cmdPayload		list of each bit in the payload of the command
+        Output: 
+            state		True/False/'pause'
+            replyPayload	list of each bit in the payload of the frame
+        '''
+
+        if cmdPayload[1] == '9': # OBC sends a frame
+            TXFrame = self.DataToFrame(cmdPayload[2], cmdPayload[4], cmdPayload[5:])
+            self.TXBuffer.put(TXFrame)
+            return 'pause', ['20', '0'] # palse the virtual bus
+        elif cmdPayload[1] == '4': # OBC takes a frame
+            if self.RXBuffer.empty():
+                return True, ['20', '0']
+            else:
+                RXFrame = self.RXBuffer.get()
+                rawMsg, src, dest, serviceNum, payload = self.FrameToData(RXFrame)
+                replyPayload = ['20', '0']
+                replyPayload.extend(rawMsg)
+                return True, replyPayload

--- a/PQ9VirtualBus.py
+++ b/PQ9VirtualBus.py
@@ -1,0 +1,72 @@
+import PQ9Client
+import PQ9Emulators
+import queue
+
+class PQ9VirtualBus():
+    '''
+    If you want to use multiple emulators, or want to mix real hardware and virtual emulators,
+    use VirtualBus. VirtualBus.processCommand() is like PQ9Client.processCommand()
+    '''
+
+    def __init__(self, master, commEmulator, emulatorDict):
+        '''
+        Input:
+            master		PQ9Client (if a real OBC is used) / OBCEmulator
+            commsEmulator	
+            emulatorDict	a dict of all emulators {'addr1': emulator 1, 'addr 2': emulator2, ...}
+        '''
+
+        self.master = master
+        self.comm = commEmulator
+        self.emuDict = emulatorDict
+        self.fo = open('VirtualBusLog.pq9', 'w')
+        self.postProcessFrame = {}
+
+    def processCommand(self, cmd):
+        '''
+        Put a command in the RX buffer of commEmulator, and then run the scheduler.
+        If the scheduler is paused, take a command from the TX buffer of commEmulator and return.
+        It can only process a SINGLE command at this stage, but can be expanded
+
+        Input:
+            master		PQ9Client (if a real OBC is used) / OBCEmulator
+            commsEmulator	
+            emulatorDict	a dict of all emulators {'addr1': emulator 1, 'addr 2': emulator2, ...}
+        '''
+
+        self.comm.RXBuffer.put(cmd)
+        self.scheduler()
+        return True, self.comm.TXBuffer.get()
+
+    def scheduler(self):
+       '''
+        Take a frame from the master. If needed, transfer the frame to a hardware module / emulator
+        and send the reply to the master. scheduler() also logs every frames on the bus and may insert faults
+
+        If an emulator returns 'pause' as its state, scheduler() will return and gives control to user's code. 
+        In this case, scheduler() will not send the reply until restart, so it can capture as many frames on the bus as possible.
+      '''
+
+        if self.postProcessFrame != {}:
+            self.master.sendFrame(postProcessFrame)
+            self.postProessFrame = {}
+
+        while True:
+            cmd = self.master.getFrame()
+            self.fo.write(cmd)
+            if type(master) == PQ9Client: # There is a real OBC
+                if cmd['dest'] in emuDict:
+                    state, reply = self.emuDict[cmd['dest']].processCommand(cmd)
+                else:
+                    continue
+            elif type(master) == PQ9Emulator: # There is a virtual OBC
+                if cmd['dest'] in emuDict:
+                    state, reply = self.emuDict[cmd['dest']].processCommand(cmd)
+                else:
+                    state, reply = self.master.processCommand(cmd)
+
+            if state == 'pause':
+                self.postProessFrame = reply
+                return
+            else:
+                self.master.sendFrame(reply)

--- a/test_HowToUseEmulators.py
+++ b/test_HowToUseEmulators.py
@@ -1,0 +1,29 @@
+import PQ9Client
+import PQ9Emulators
+import PQ9VirtualBus
+import pytest
+import time
+from PQ9TestHelpers import getAddress
+
+'''
+1. If you want to test a single emulator:
+pq9_connection = COMMSEmulator('4')
+destination = '4'
+
+2. If you want to send commands to a module through virtual COMMS and
+real OBC:
+commsEmu = COMMSEmulator('4')
+pq9_connection = PQ9VirtualBus(PQ9Client, commsEmu, {'4':commsEmu})
+destination = 'x'
+'''
+def test_SinglePing(pq9_connection, destination):    
+    command = {}
+    command["_send_"] = "SendRaw"
+    command["dest"] = destination
+    command["src"] = "8"
+    command["data"] = "17 1"
+    startTime = time.time()
+    succes, msg = pq9_connection.processCommand(command)
+    elapsedTime = time.time() - startTime
+    assert succes == True, "System is not responding"
+    print("Elapsed time: ", round(elapsedTime * 1000, 0), " ms")


### PR DESCRIPTION
Hello!

I create some code for emulators which is very simple (less than 100 lines) and flexible. It has 3 files: 
    - `PQ9Emulators.py` (definition of emulators), 
    - `PQ9VirtualBus.py` (connect emulators to the bus and provide interface to users)
    - `test_HowToUseEmulators.py` (examples of user's code).

**What can it do?**

In the message flow: Ground Station <-> COMMS <-> OBC <-> Module X
    - It can simulate any module, also supports mixing real modules and virtual emulators. 
    - The code for Ground Station will be independent from emulators, which means you can reuse it in the mission.
    - PQ9VirtualBus logs every frame over the bus and may insert fault

**How to use it?**

If you want to send a command to a single emulator, use `EmulatorX.processCommand()` after initializing EmulatorX

If you want to send a command to a virtual bus, use `VirtualBus.processCommand()` after initializing emulators and the virtual bus.

`test_HowToUseEmulators.py` provides more information.

**How does it work?**

Here is the function flow:
1. User's code initializes `PQ9VirtualBus` and `PQ9Emulators`. An emulator of COMMS is necessary for `PQ9VirtualBus`, if you want to send commands and an OBC exists.
2. User's code calls `PQ9VirtualBus.processCommand()`. A command will be put in the RX buffer of `COMMSEmulator`. After that, `PQ9VirtualBus.scheduler()` will be run.
3. The scheduler transfers messages among modules, until it gets a 'pause' state from a module. Generally, after `COMMSEmulator` puts a frame in its TX buffer, it will return a 'pause' state.
4. `PQ9VirtualBus.scheduler()` returns. `PQ9VirtualBus.processCommand()` retrieves a frame from the TX buffer of `COMMSEmulator` and then returns.
5. User's code gets reply from `PQ9VirtualBus.processCommand()` and continues other operations.

**Not fully implemented**

1. At this stage, it can only processes commands with cmd['_send_'] = 'SendRaw'
2. Only COMMEmulator is partly implemented
3. PQ9VirtualBus is not tested yet